### PR TITLE
Update the test.pdf filename to real filename

### DIFF
--- a/src/WiziYousignClient/WiziSignClient.php
+++ b/src/WiziYousignClient/WiziSignClient.php
@@ -177,8 +177,8 @@ class WiziSignClient
         $data = file_get_contents($filepath);
         $b64Doc = base64_encode($data);
 
-        $names = explode('/', $test);
-        $filename = $names[count($test2) - 1];
+        $names = explode('/', $filepath);
+        $filename = $names[count($names) - 1];
         
         $post = array(
             'name' => $filename,

--- a/src/WiziYousignClient/WiziSignClient.php
+++ b/src/WiziYousignClient/WiziSignClient.php
@@ -177,8 +177,11 @@ class WiziSignClient
         $data = file_get_contents($filepath);
         $b64Doc = base64_encode($data);
 
+        $names = explode('/', $test);
+        $filename = $names[count($test2) - 1];
+        
         $post = array(
-            'name' => 'test.pdf',
+            'name' => $filename,
             'content' => $b64Doc
         );
         $p = json_encode($post);


### PR DESCRIPTION
Hi.
Thanks for this lib.
The filename sent to yousign is currently a static name test.pdf. I modified this so that the filename could be obtained from the filepath parameter.

Thanks !